### PR TITLE
Create Docker Compose config to consume backend metrics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
         with:
           context: ./backend
           push: true
-          tags: ghcr.io/${{ env.OWNER_LC }}/searchhn-backend:${{ github.sha }}
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/searchhn-backend:${{ github.sha }}
+            ghcr.io/${{ env.OWNER_LC }}/searchhn-backend:canary
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+## SearchHN

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,12 +7,12 @@ COPY . .
 RUN cargo build --release 
 
 # Runtime stage
-FROM debian:bullseye
+FROM debian:bookworm-slim
 # Set logging
 ENV RUST_LOG=info
 # Install runtime dependencies for OpenSSL and Postgres
 RUN apt-get update && \
-    apt-get install -y libssl1.1 libssl-dev libpq5 protobuf-compiler curl && \
+    apt-get install -y libssl-dev libpq5 curl && \
     rm -rf /var/lib/apt/lists/*
 # Copy in the backend binary
 COPY --from=builder /usr/src/app/target/release/backend /usr/local/bin

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ FROM debian:bullseye
 ENV RUST_LOG=info
 # Install runtime dependencies for OpenSSL and Postgres
 RUN apt-get update && \
-    apt-get install -y libssl1.1 libpq5 protobuf-compiler curl && \
+    apt-get install -y libssl1.1 libssl-dev libpq5 protobuf-compiler curl && \
     rm -rf /var/lib/apt/lists/*
 # Copy in the backend binary
 COPY --from=builder /usr/src/app/target/release/backend /usr/local/bin

--- a/infra/README.md
+++ b/infra/README.md
@@ -8,7 +8,12 @@ Set:
 POSTGRES_USER=""
 POSTGRES_PASSWORD=""
 POSTGRES_DB=""
+# For Prometheus.
+# Remember that backend is running on this network in prod on 3000
 BACKEND_URL=""
+# For backend.
+# In prod, remember database is running on this network on 5432
+DATABASE_URL=""
 ```
 
 ## Local development
@@ -21,4 +26,10 @@ docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
 
 ```bash
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up
+```
+
+To update:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml  pull
 ```

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,24 @@
+# Docker Compose stacks
+
+## Environment variables
+
+Set:
+
+```bash
+POSTGRES_USER=""
+POSTGRES_PASSWORD=""
+POSTGRES_DB=""
+BACKEND_URL=""
+```
+
+## Local development
+
+```bash
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
+## Production
+
+```bash
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml up
+```

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,0 +1,5 @@
+services:
+  prometheus:
+    network_mode: host
+    volumes:
+      - ./prometheus-config/prometheus.dev.yml:/etc/prometheus/prometheus.yml

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,0 +1,14 @@
+services:
+  backend:
+    image: ghcr.io/endlessreform/searchhn-backend:5de4cfaed521a0f1e89d909601d3d088755c3d3e
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+    command: [ "backend", "--catchup-amt", "1000000" ]
+    ports:
+      - "3000:3000"
+
+  prometheus:
+    volumes:
+      - ./prometheus-config/prometheus.prod.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   backend:
-    image: ghcr.io/endlessreform/searchhn-backend:5de4cfaed521a0f1e89d909601d3d088755c3d3e
+    image: ghcr.io/endlessreform/searchhn-backend:canary
     environment:
       - DATABASE_URL=${DATABASE_URL}
     command: [ "backend", "--catchup-amt", "1000000" ]

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:15
@@ -21,9 +19,6 @@ services:
     restart: always
     volumes:
       - prometheus_data:/prometheus
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-    ports:
-      - "9090:9090"
 
 volumes:
   postgres_data:

--- a/infra/prometheus-config/prometheus.dev.yml
+++ b/infra/prometheus-config/prometheus.dev.yml
@@ -5,3 +5,9 @@ scrape_configs:
   - job_name: "prometheus"
     static_configs:
       - targets: ["localhost:9090"]
+
+  - job_name: "backend"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets:
+        - 'localhost:3000'

--- a/infra/prometheus-config/prometheus.prod.yml
+++ b/infra/prometheus-config/prometheus.prod.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "backend"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets:
+        - 'backend:3000'


### PR DESCRIPTION
This PR adds:
- Dev and prod configs for Prometheus monitoring to consume telemetry from #4
- Canary tag for GHCR backend images in CI
- Fix to Dockerfile: Update Debian image to match Rust builder for 1.78, fix SSL headers, remove Protobuf

Currently at ~4 minutes per million records...