### PR TITLE
Prometheus metrics for realtime, fix logging

### DIFF
--- a/backend/lib/server/mod.rs
+++ b/backend/lib/server/mod.rs
@@ -3,7 +3,7 @@ use crate::state::AppState;
 use prometheus_client::encoding::text::encode;
 
 use axum::{extract::State, routing::get, Router};
-use monitoring::CRAWLER_METRICS;
+use monitoring::{CATCHUP_METRICS, REALTIME_METRICS};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -23,8 +23,16 @@ pub async fn setup_server(state: Arc<AppState>) -> tokio::task::JoinHandle<()> {
     {
         let mut registry = state.registry.write().await;
 
-        CRAWLER_METRICS
-            .get_or_init(|| async { monitoring::CrawlerMetrics::register(&mut registry) })
+        CATCHUP_METRICS
+            .get_or_init(|| async {
+                monitoring::CatchupMetrics::register(&mut registry, "catchup")
+            })
+            .await;
+
+        REALTIME_METRICS
+            .get_or_init(|| async {
+                monitoring::RealtimeMetrics::register(&mut registry, "realtime")
+            })
             .await;
     }
 

--- a/backend/lib/server/monitoring.rs
+++ b/backend/lib/server/monitoring.rs
@@ -1,14 +1,14 @@
-use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
 use prometheus_client::registry::Registry;
 use tokio::sync::OnceCell;
 
 #[derive(Clone)]
-pub struct CrawlerMetrics {
+pub struct CatchupMetrics {
     pub records_pulled: Counter,
     pub error_count: Counter,
 }
 
-impl CrawlerMetrics {
+impl CatchupMetrics {
     fn init() -> Self {
         Self {
             records_pulled: Counter::default(),
@@ -16,22 +16,61 @@ impl CrawlerMetrics {
         }
     }
 
-    pub fn register(registry: &mut Registry) -> Self {
+    pub fn register(registry: &mut Registry, prefix: &str) -> Self {
         let metrics = Self::init();
-
-        registry.register(
+        let sub_registry = registry.sub_registry_with_prefix(prefix);
+        sub_registry.register(
             "records_pulled",
             "Total number of records pulled",
             metrics.records_pulled.clone(),
         );
-        registry.register(
+        sub_registry.register(
             "error_count",
             "Total number of errors encountered",
             metrics.error_count.clone(),
         );
-
         metrics
     }
 }
 
-pub static CRAWLER_METRICS: OnceCell<CrawlerMetrics> = OnceCell::const_new();
+pub static CATCHUP_METRICS: OnceCell<CatchupMetrics> = OnceCell::const_new();
+
+#[derive(Clone)]
+pub struct RealtimeMetrics {
+    pub batch_size: Gauge,
+    pub records_pulled: Counter,
+    pub records_failed: Counter,
+}
+
+impl RealtimeMetrics {
+    fn init() -> Self {
+        Self {
+            batch_size: Gauge::default(),
+            records_pulled: Counter::default(),
+            records_failed: Counter::default(),
+        }
+    }
+
+    pub fn register(registry: &mut Registry, prefix: &str) -> Self {
+        let metrics = Self::init();
+        let sub_registry = registry.sub_registry_with_prefix(prefix);
+        sub_registry.register(
+            "batch_size",
+            "Number of records in each batch",
+            metrics.batch_size.clone(),
+        );
+        sub_registry.register(
+            "records_processed_total",
+            "Total number of successfully processed records",
+            metrics.records_pulled.clone(),
+        );
+        sub_registry.register(
+            "records_failed_total",
+            "Total number of records that failed processing",
+            metrics.records_failed.clone(),
+        );
+        metrics
+    }
+}
+
+pub static REALTIME_METRICS: OnceCell<RealtimeMetrics> = OnceCell::const_new();


### PR DESCRIPTION
This PR fixes:
- Logging for individual stories removed
- Keepalive connections no longer marked as error
- Prometheus monitoring for batch size, total realtime count